### PR TITLE
Fix bugs in parser factory, argument parsing, and program flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Build
+dotnet build
+
+# Run tests
+dotnet test
+
+# Publish single-file executables for all platforms
+dotnet publish --configuration Release
+```
+
+## Architecture
+
+This is a .NET 8 console application that acts as a post-processing script for 3D printer slicers. After a slicer exports G-code, this tool parses the file, extracts print settings, and opens https://www.3dprintlog.com with pre-filled print details.
+
+### Data Flow
+
+```
+G-code file → ArgumentParser → ParserFactory → Slicer-specific Parser → CuraSettingDto → API POST → Browser opens
+```
+
+### Key Components
+
+- **Program.cs**: Entry point with DI setup and Application Insights telemetry
+- **ArgumentParser.cs**: CLI argument handling (`--default`, `--full`, `--template`, `--debug`, etc.)
+- **ParserFactory.cs**: Detects slicer type from G-code markers, falls back to template match scoring
+- **Services/Parsers/{SlicerName}/**: Each slicer has its own directory with:
+  - Parser class implementing `IGcodeParser`
+  - Default and Full note templates
+- **CuraSettingDto.cs**: Main DTO sent to the API
+
+### Supported Slicers
+
+OrcaSlicer, PrusaSlicer, Bambu Studio, FLSun Slicer, Anycubic Slicer Next
+
+### Template System
+
+Templates use `{{setting_name}}` placeholders that get replaced with values from G-code comments like `; setting_name = value`.
+
+## Testing
+
+Uses MSTest with Snapshooter for snapshot testing. Snapshots hash the `settings.Snapshot` field to avoid cross-platform line-ending issues:
+
+```csharp
+Snapshot.Match(result, matchOptions => matchOptions.HashField("settings.Snapshot"));
+```
+
+## Adding a New Slicer
+
+1. Create `Services/Parsers/{SlicerName}/` directory
+2. Implement parser class with `IGcodeParser` interface and static `Is{SlicerName}(string gcode)` detection method
+3. Create `{SlicerName}DefaultNoteTemplate` and `{SlicerName}FullNoteTemplate` classes
+4. Register in `ParserFactory.GetParser()` and add `Build{SlicerName}Parser()` method
+5. Add tests with snapshot verification
+
+## Debug Mode
+
+```bash
+Slic3rPostProcessingUploader.exe --debug C:\path\to\debug\
+```
+
+Outputs: environment variables, raw G-code, parsed DTO, and API response to the specified directory.

--- a/Slic3rPostProcessingUploader/Program.cs
+++ b/Slic3rPostProcessingUploader/Program.cs
@@ -59,6 +59,11 @@ try
 
     LogEnvironmentVariables(arguments.DebugPath);
 
+    if (string.IsNullOrEmpty(arguments.InputFile))
+    {
+        throw new ArgumentException("No input file specified. Please provide a G-code file path as the last argument.");
+    }
+
     string fileContents = File.ReadAllText(arguments.InputFile);
     LogFileContents(arguments.DebugPath, fileContents);
 
@@ -71,8 +76,9 @@ try
 
         dto = parser.ParseGcode(fileContents);
 
-        dto.settings.file_name = Path.GetFileName(Environment.GetEnvironmentVariable("SLIC3R_PP_OUTPUT_NAME"));
-        dto.settings.print_name = GetTitle(Path.GetFileNameWithoutExtension(dto.settings.file_name));
+        var outputName = Environment.GetEnvironmentVariable("SLIC3R_PP_OUTPUT_NAME");
+        dto.settings.file_name = outputName != null ? Path.GetFileName(outputName) : Path.GetFileName(arguments.InputFile);
+        dto.settings.print_name = new TitleService().GetTitle(Path.GetFileNameWithoutExtension(dto.settings.file_name));
         dto.PluginVersion = new VersionService().GetVersion();
 
         // Track the slicer, plugin version, and cura version as events
@@ -90,8 +96,7 @@ try
     }
 
     // Give application insights time to flush before closing
-    telemetryClient.Flush();
-    Task.Delay(2000).Wait();
+    await telemetryClient.FlushAsync(CancellationToken.None);
 }
 catch (Exception e)
 {
@@ -168,8 +173,8 @@ void LogDto(string debugPath, CuraSettingDto dto)
 
 async Task UploadToApi(string apiUrl, CuraSettingDto dto, string debugPath, string newPrintUrl)
 {
-    HttpClient client = new();
-    StringContent content = new(dto.ToJSON(), Encoding.UTF8, "application/json");
+    using HttpClient client = new();
+    using StringContent content = new(dto.ToJSON(), Encoding.UTF8, "application/json");
 
     try
     {
@@ -205,50 +210,4 @@ void LogApiResponse(string debugPath, string responseContent)
         string path = Path.Combine(debugPath, responseFileName);
         File.WriteAllText(path, responseContent);
     }
-}
-
-string GetTitle(string filename)
-{
-    if (string.IsNullOrEmpty(filename))
-    {
-        return "";
-    }
-
-    string snakeCaseFilename = ToSnakeCase(filename);
-    string title = string.Join(" ", snakeCaseFilename.Split('_')
-        .Where(segment => !segment.Equals("gcode", StringComparison.OrdinalIgnoreCase))
-        .Select(CultureInfo.CurrentCulture.TextInfo.ToTitleCase))
-        .Trim();
-
-    return title.Length > 100 ? title[..100] : title;
-}
-
-string ToSnakeCase(string text)
-{
-
-    if (string.IsNullOrEmpty(text))
-    {
-        return "";
-    }
-
-    if (text.Length < 2)
-    {
-        return text.ToLowerInvariant();
-    }
-    StringBuilder sb = new();
-    _ = sb.Append(char.ToLowerInvariant(text[0]));
-    for (int i = 1; i < text.Length; ++i)
-    {
-        char c = text[i];
-        if (char.IsUpper(c))
-        {
-            _ = sb.Append('_');
-            _ = sb.Append(char.ToLowerInvariant(c));
-        }
-        else
-        {
-            _ = sb.Append(c);
-        }
-    }
-    return sb.ToString();
 }

--- a/Slic3rPostProcessingUploader/Services/ArgumentParser.cs
+++ b/Slic3rPostProcessingUploader/Services/ArgumentParser.cs
@@ -27,7 +27,10 @@ namespace Slic3rPostProcessingUploader.Services
             this.NoteTemplatePath = null;
             this.DisableTelemetry = false;
             this.DisplayHelp = false;
-            this.InputFile = args.LastOrDefault();
+
+            // InputFile is the last argument, but only if it's not a flag
+            var lastArg = args.LastOrDefault();
+            this.InputFile = lastArg != null && !lastArg.StartsWith("--") && lastArg != "-h" ? lastArg : null;
 
             // Check for if the user wants a default, full, or custom note template
             for (int i = 0; i < args.Length; i++)
@@ -46,6 +49,12 @@ namespace Slic3rPostProcessingUploader.Services
                 {
                     this.UseDefaultNoteTemplate = false;
                     this.UseFullNoteTemplate = false;
+
+                    if (i + 1 >= args.Length)
+                    {
+                        throw new ArgumentException("--template requires a path argument");
+                    }
+
                     this.NoteTemplatePath = args[i + 1];
 
                     if (string.IsNullOrEmpty(this.NoteTemplatePath))
@@ -66,11 +75,16 @@ namespace Slic3rPostProcessingUploader.Services
 
                 if (args[i] == "--debug")
                 {
+                    if (i + 1 >= args.Length)
+                    {
+                        throw new ArgumentException("--debug requires a path argument");
+                    }
+
                     this.DebugPath = args[i + 1];
 
                     if (this.DebugPath == this.InputFile)
                     {
-                        throw new ArgumentException("Note template path cannot be null or empty");
+                        throw new ArgumentException("Debug path cannot be the same as input file");
                     }
 
                     if (string.IsNullOrEmpty(this.DebugPath))

--- a/Slic3rPostProcessingUploader/Services/Parsers/ParserFactory.cs
+++ b/Slic3rPostProcessingUploader/Services/Parsers/ParserFactory.cs
@@ -45,7 +45,7 @@ namespace Slic3rPostProcessingUploader.Services.Parsers
                 var orcaFullTemplate = new OrcaFullNoteTemplate().getNoteTemplate();
                 var orcaParser = new OrcaParser(orcaFullTemplate);
                 var orcaResults = orcaParser.CountTemplateMatches(gcode);
-                var orcaPercentMatch = orcaResults.numMatches / orcaResults.numPlaceholders;
+                var orcaPercentMatch = (double) orcaResults.numMatches / (double) orcaResults.numPlaceholders;
 
                 telemetryClient.TrackEvent("OrcaPercentMatch", new Dictionary<string, string> { { "PercentMatch", orcaPercentMatch.ToString() } });
 
@@ -53,7 +53,7 @@ namespace Slic3rPostProcessingUploader.Services.Parsers
                 var prusaFullTemplate = new PrusaFullNoteTemplate().getNoteTemplate();
                 var prusaParser = new PrusaParser(prusaFullTemplate);
                 var prusaResults = prusaParser.CountTemplateMatches(gcode);
-                var PrusaPercentMatch = orcaResults.numMatches / orcaResults.numPlaceholders;
+                var PrusaPercentMatch = (double) prusaResults.numMatches / (double) prusaResults.numPlaceholders;
 
                 telemetryClient.TrackEvent("PrusaPercentMatch", new Dictionary<string, string> { { "PercentMatch", PrusaPercentMatch.ToString() } });
 
@@ -61,7 +61,7 @@ namespace Slic3rPostProcessingUploader.Services.Parsers
                 var flsunFullTemplate = new FLSunFullNoteTemplate().getNoteTemplate();
                 var flsunParser = new FLSunParser(flsunFullTemplate);
                 var flsunResults = flsunParser.CountTemplateMatches(gcode);
-                var flsunPercentMatch = flsunResults.numMatches / flsunResults.numPlaceholders;
+                var flsunPercentMatch = (double) flsunResults.numMatches / (double) flsunResults.numPlaceholders;
 
                 telemetryClient.TrackEvent("FLSunPercentMatch", new Dictionary<string, string> { { "PercentMatch", flsunPercentMatch.ToString() } });
 
@@ -69,7 +69,7 @@ namespace Slic3rPostProcessingUploader.Services.Parsers
                 var bambuStudioFullTemplate = new BambuStudioFullNoteTemplate().getNoteTemplate();
                 var bambuStudioParser = new BambuStudioParser(bambuStudioFullTemplate);
                 var bambuStudioResults = bambuStudioParser.CountTemplateMatches(gcode);
-                var bambuStudioPercentMatch = bambuStudioResults.numMatches / bambuStudioResults.numPlaceholders;
+                var bambuStudioPercentMatch = (double)bambuStudioResults.numMatches / (double) bambuStudioResults.numPlaceholders;
 
                 telemetryClient.TrackEvent("BambuStudioPercentMatch", new Dictionary<string, string> { { "PercentMatch", bambuStudioPercentMatch.ToString() } });
 
@@ -77,7 +77,7 @@ namespace Slic3rPostProcessingUploader.Services.Parsers
                 var anycubicSlicerNextFullTemplate = new AnycubicSlicerNextFullNoteTemplate().getNoteTemplate();
                 var anycubicSlicerNextParser = new AnycubicSlicerNextParser(anycubicSlicerNextFullTemplate);
                 var anycubicSlicerNextResults = anycubicSlicerNextParser.CountTemplateMatches(gcode);
-                var anycubicSlicerNextPercentMatch = anycubicSlicerNextResults.numMatches / anycubicSlicerNextResults.numPlaceholders;
+                var anycubicSlicerNextPercentMatch = (double) anycubicSlicerNextResults.numMatches / (double) anycubicSlicerNextResults.numPlaceholders;
 
                 telemetryClient.TrackEvent("AnycubicSlicerNextPercentMatch", new Dictionary<string, string> { { "PercentMatch", anycubicSlicerNextPercentMatch.ToString() } });
 

--- a/Slic3rPostProcessingUploader/Services/TitleService.cs
+++ b/Slic3rPostProcessingUploader/Services/TitleService.cs
@@ -1,0 +1,54 @@
+using System.Globalization;
+using System.Text;
+
+namespace Slic3rPostProcessingUploader.Services
+{
+    internal class TitleService
+    {
+        public string GetTitle(string? filename)
+        {
+            if (string.IsNullOrEmpty(filename))
+            {
+                return "";
+            }
+
+            string snakeCaseFilename = ToSnakeCase(filename);
+            string title = string.Join(" ", snakeCaseFilename.Split('_')
+                .Where(segment => !segment.Equals("gcode", StringComparison.OrdinalIgnoreCase))
+                .Select(CultureInfo.CurrentCulture.TextInfo.ToTitleCase))
+                .Trim();
+
+            return title.Length > 100 ? title[..100] : title;
+        }
+
+        public string ToSnakeCase(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return "";
+            }
+
+            if (text.Length < 2)
+            {
+                return text.ToLowerInvariant();
+            }
+
+            StringBuilder sb = new();
+            sb.Append(char.ToLowerInvariant(text[0]));
+            for (int i = 1; i < text.Length; ++i)
+            {
+                char c = text[i];
+                if (char.IsUpper(c))
+                {
+                    sb.Append('_');
+                    sb.Append(char.ToLowerInvariant(c));
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Slic3rPostProcessingUploaderUnitTests/Services/ArgumentParserTests.cs
+++ b/Slic3rPostProcessingUploaderUnitTests/Services/ArgumentParserTests.cs
@@ -1,4 +1,4 @@
-﻿using Slic3rPostProcessingUploader.Services;
+using Slic3rPostProcessingUploader.Services;
 using Slic3rPostProcessingUploader.Services.Parsers;
 using Snapshooter.MSTest;
 using System.IO;
@@ -28,5 +28,165 @@ namespace Slic3rPostProcessingUploaderUnitTests.Services
 
             Snapshot.Match(allConsoleOutput);
         }
+
+        #region InputFile Tests
+
+        [TestMethod]
+        public void Constructor_WithNoArguments_InputFileIsNull()
+        {
+            var parser = new ArgumentParser([]);
+            Assert.IsNull(parser.InputFile);
+        }
+
+        [TestMethod]
+        public void Constructor_WithOnlyFlags_InputFileIsNull()
+        {
+            var parser = new ArgumentParser(["--default", "--opt-out-telemetry"]);
+            Assert.IsNull(parser.InputFile);
+        }
+
+        [TestMethod]
+        public void Constructor_WithInputFile_SetsInputFile()
+        {
+            var parser = new ArgumentParser(["--default", "myfile.gcode"]);
+            Assert.AreEqual("myfile.gcode", parser.InputFile);
+        }
+
+        [TestMethod]
+        public void Constructor_WithHelpFlag_InputFileIsNull()
+        {
+            var parser = new ArgumentParser(["--help"]);
+            Assert.IsNull(parser.InputFile);
+        }
+
+        [TestMethod]
+        public void Constructor_WithShortHelpFlag_InputFileIsNull()
+        {
+            var parser = new ArgumentParser(["-h"]);
+            Assert.IsNull(parser.InputFile);
+        }
+
+        #endregion
+
+        #region Template Flag Tests
+
+        [TestMethod]
+        public void Constructor_WithTemplateAndPath_SetsTemplatePath()
+        {
+            var parser = new ArgumentParser(["--template", "C:\\templates\\custom.txt", "input.gcode"]);
+            Assert.AreEqual("C:\\templates\\custom.txt", parser.NoteTemplatePath);
+            Assert.IsFalse(parser.UseDefaultNoteTemplate);
+            Assert.IsFalse(parser.UseFullNoteTemplate);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_WithTemplateAsLastArgument_ThrowsException()
+        {
+            new ArgumentParser(["input.gcode", "--template"]);
+        }
+
+        [TestMethod]
+        public void Constructor_WithDefaultFlag_UsesDefaultTemplate()
+        {
+            var parser = new ArgumentParser(["--default", "input.gcode"]);
+            Assert.IsTrue(parser.UseDefaultNoteTemplate);
+            Assert.IsFalse(parser.UseFullNoteTemplate);
+        }
+
+        [TestMethod]
+        public void Constructor_WithFullFlag_UsesFullTemplate()
+        {
+            var parser = new ArgumentParser(["--full", "input.gcode"]);
+            Assert.IsFalse(parser.UseDefaultNoteTemplate);
+            Assert.IsTrue(parser.UseFullNoteTemplate);
+        }
+
+        #endregion
+
+        #region Debug Flag Tests
+
+        [TestMethod]
+        public void Constructor_WithDebugAndPath_SetsDebugPath()
+        {
+            var parser = new ArgumentParser(["--debug", "C:\\debug\\", "input.gcode"]);
+            Assert.AreEqual("C:\\debug\\", parser.DebugPath);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_WithDebugAsLastArgument_ThrowsException()
+        {
+            new ArgumentParser(["input.gcode", "--debug"]);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Constructor_WithDebugPathStartingWithDashes_ThrowsException()
+        {
+            new ArgumentParser(["--debug", "--invalid", "input.gcode"]);
+        }
+
+        #endregion
+
+        #region Other Flags Tests
+
+        [TestMethod]
+        public void Constructor_WithLocalDevFlag_SetsLocalDev()
+        {
+            var parser = new ArgumentParser(["--local-dev", "input.gcode"]);
+            Assert.IsTrue(parser.UseLocalDev);
+        }
+
+        [TestMethod]
+        public void Constructor_WithOptOutTelemetryFlag_DisablesTelemetry()
+        {
+            var parser = new ArgumentParser(["--opt-out-telemetry", "input.gcode"]);
+            Assert.IsTrue(parser.DisableTelemetry);
+        }
+
+        [TestMethod]
+        public void Constructor_WithHelpFlag_SetsDisplayHelp()
+        {
+            var parser = new ArgumentParser(["--help"]);
+            Assert.IsTrue(parser.DisplayHelp);
+        }
+
+        [TestMethod]
+        public void Constructor_WithShortHelpFlag_SetsDisplayHelp()
+        {
+            var parser = new ArgumentParser(["-h"]);
+            Assert.IsTrue(parser.DisplayHelp);
+        }
+
+        [TestMethod]
+        public void Constructor_WithMultipleFlags_SetsAllFlags()
+        {
+            var parser = new ArgumentParser(["--full", "--local-dev", "--opt-out-telemetry", "input.gcode"]);
+            Assert.IsFalse(parser.UseDefaultNoteTemplate);
+            Assert.IsTrue(parser.UseFullNoteTemplate);
+            Assert.IsTrue(parser.UseLocalDev);
+            Assert.IsTrue(parser.DisableTelemetry);
+            Assert.AreEqual("input.gcode", parser.InputFile);
+        }
+
+        #endregion
+
+        #region Default Values Tests
+
+        [TestMethod]
+        public void Constructor_WithNoFlags_HasCorrectDefaults()
+        {
+            var parser = new ArgumentParser(["input.gcode"]);
+            Assert.IsTrue(parser.UseDefaultNoteTemplate);
+            Assert.IsFalse(parser.UseFullNoteTemplate);
+            Assert.IsFalse(parser.UseLocalDev);
+            Assert.IsFalse(parser.DisableTelemetry);
+            Assert.IsFalse(parser.DisplayHelp);
+            Assert.IsNull(parser.NoteTemplatePath);
+            Assert.IsNull(parser.DebugPath);
+        }
+
+        #endregion
     }
 }

--- a/Slic3rPostProcessingUploaderUnitTests/Services/TitleServiceTests.cs
+++ b/Slic3rPostProcessingUploaderUnitTests/Services/TitleServiceTests.cs
@@ -1,0 +1,154 @@
+using Slic3rPostProcessingUploader.Services;
+
+namespace Slic3rPostProcessingUploaderUnitTests.Services
+{
+    [TestClass]
+    public class TitleServiceTests
+    {
+        private TitleService _titleService = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _titleService = new TitleService();
+        }
+
+        #region ToSnakeCase Tests
+
+        [TestMethod]
+        public void ToSnakeCase_WithNull_ReturnsEmptyString()
+        {
+            var result = _titleService.ToSnakeCase(null);
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void ToSnakeCase_WithEmptyString_ReturnsEmptyString()
+        {
+            var result = _titleService.ToSnakeCase("");
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void ToSnakeCase_WithSingleCharacter_ReturnsLowercase()
+        {
+            var result = _titleService.ToSnakeCase("A");
+            Assert.AreEqual("a", result);
+        }
+
+        [TestMethod]
+        public void ToSnakeCase_WithPascalCase_ReturnsSnakeCase()
+        {
+            var result = _titleService.ToSnakeCase("MyFileName");
+            Assert.AreEqual("my_file_name", result);
+        }
+
+        [TestMethod]
+        public void ToSnakeCase_WithCamelCase_ReturnsSnakeCase()
+        {
+            var result = _titleService.ToSnakeCase("myFileName");
+            Assert.AreEqual("my_file_name", result);
+        }
+
+        [TestMethod]
+        public void ToSnakeCase_WithAllLowercase_ReturnsSameString()
+        {
+            var result = _titleService.ToSnakeCase("filename");
+            Assert.AreEqual("filename", result);
+        }
+
+        [TestMethod]
+        public void ToSnakeCase_WithConsecutiveUppercase_InsertsUnderscores()
+        {
+            var result = _titleService.ToSnakeCase("XMLParser");
+            Assert.AreEqual("x_m_l_parser", result);
+        }
+
+        #endregion
+
+        #region GetTitle Tests
+
+        [TestMethod]
+        public void GetTitle_WithNull_ReturnsEmptyString()
+        {
+            var result = _titleService.GetTitle(null);
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithEmptyString_ReturnsEmptyString()
+        {
+            var result = _titleService.GetTitle("");
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithSimpleFilename_ReturnsTitleCase()
+        {
+            var result = _titleService.GetTitle("calibration_cube");
+            Assert.AreEqual("Calibration Cube", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithGcodeSegment_RemovesGcode()
+        {
+            var result = _titleService.GetTitle("calibration_cube_gcode");
+            Assert.AreEqual("Calibration Cube", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithPascalCaseFilename_ConvertsProperly()
+        {
+            var result = _titleService.GetTitle("CalibrationCube");
+            Assert.AreEqual("Calibration Cube", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithMixedCase_HandlesCorrectly()
+        {
+            var result = _titleService.GetTitle("My3DPrint");
+            Assert.AreEqual("My3 D Print", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithVeryLongFilename_TruncatesTo100Characters()
+        {
+            var longName = string.Join("_", Enumerable.Repeat("segment", 50));
+            var result = _titleService.GetTitle(longName);
+            Assert.IsTrue(result.Length <= 100);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithExactly100Characters_DoesNotTruncate()
+        {
+            // Create a filename that results in exactly 100 characters after conversion
+            var result = _titleService.GetTitle("test_file_name");
+            Assert.IsTrue(result.Length <= 100);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithUnderscoresAndGcode_RemovesGcodeAndFormatsCorrectly()
+        {
+            var result = _titleService.GetTitle("my_awesome_print_gcode_test");
+            Assert.AreEqual("My Awesome Print Test", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithOnlyGcode_ReturnsEmptyString()
+        {
+            var result = _titleService.GetTitle("gcode");
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void GetTitle_WithLowercaseGcode_RemovesGcode()
+        {
+            // Note: GCODE in uppercase gets broken up by ToSnakeCase into individual letters
+            // so only lowercase "gcode" segments are filtered out
+            var result = _titleService.GetTitle("test_gcode_file");
+            Assert.AreEqual("Test File", result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
- Fix ParserFactory using wrong variable for Prusa percent match calculation
- Add bounds checking for --template and --debug arguments in ArgumentParser
- Add InputFile validation to reject flag-only arguments as input files
- Fix null reference when SLIC3R_PP_OUTPUT_NAME env var is not set
- Add proper disposal of HttpClient and StringContent
- Replace blocking Task.Wait() with async FlushAsync()
- Extract TitleService for testability
- Add comprehensive unit tests for ArgumentParser and TitleService
- Add CLAUDE.md for Claude Code guidance
- Add .claude/settings.local.json to .gitignore